### PR TITLE
Implement dynamic front page and navigation script

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,11 @@
 Minimal G-Style — Responsive Pro (v1.5.0)
-Per-device controls (Mobile/Tablet/Desktop) + grid, header density, search height, featured image max-height, and more.
+
+Lightweight glassmorphism theme with per-device customization and a dynamic front page.
+
+Features:
+- Neo Glass aesthetic with lime/pink accents
+- Customizer: container width, grid columns, brand size, search height, featured image max, and more per device
+- Sticky header, table of contents, breadcrumb, mobile bottom navigation toggles
+- Front page highlights latest articles and quick category chips
+
 Install: Upload ZIP → Activate → Customize → Minimal G-Style — Advanced UI.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const menuToggle=document.getElementById('menuToggle');
+  const mobileNav=document.getElementById('mobileNav');
+  if(menuToggle && mobileNav){
+    const toggle=()=>{
+      const expanded=menuToggle.getAttribute('aria-expanded')==='true';
+      menuToggle.setAttribute('aria-expanded',(!expanded).toString());
+      mobileNav.hidden=expanded;
+      mobileNav.style.display=expanded?'none':'block';
+    };
+    menuToggle.addEventListener('click',toggle);
+    document.addEventListener('keydown',e=>{if(e.key==='Escape'){mobileNav.hidden=true;menuToggle.setAttribute('aria-expanded','false');}});
+  }
+
+  const search=document.getElementById('mg-search');
+  const suggest=document.getElementById('mg-suggest');
+  if(search && suggest){
+    let timer;
+    search.addEventListener('input',()=>{
+      clearTimeout(timer);
+      const q=search.value.trim();
+      if(!q){suggest.style.display='none';return;}
+      timer=setTimeout(()=>{
+        fetch(MG.rest+'wp/v2/search?search='+encodeURIComponent(q)+'&_fields=title,url&per_page=5')
+        .then(r=>r.json()).then(data=>{
+          if(!data.length){suggest.style.display='none';return;}
+          suggest.innerHTML=data.map(it=>`<a class="suggest-item" href="${it.url}">${it.title}</a>`).join('');
+          suggest.style.display='block';
+        });
+      },200);
+    });
+    document.addEventListener('click',e=>{if(!suggest.contains(e.target) && e.target!==search) suggest.style.display='none';});
+  }
+
+  const tocList=document.getElementById('toc-list');
+  if(tocList){
+    const headers=document.querySelectorAll('.entry-content h2, .entry-content h3');
+    headers.forEach((h,i)=>{
+      if(!h.id) h.id='h-'+i;
+      const li=document.createElement('li');
+      li.innerHTML=`<a href="#${h.id}">${h.textContent}</a>`;
+      tocList.appendChild(li);
+    });
+  }
+
+  const progress=document.getElementById('progress');
+  const toTop=document.getElementById('toTop');
+  const onScroll=()=>{
+    const h=document.documentElement.scrollHeight-window.innerHeight;
+    const y=window.scrollY;
+    if(progress) progress.style.width=(y/h*100)+'%';
+    if(toTop) toTop.style.display=y>300?'block':'none';
+  };
+  window.addEventListener('scroll',onScroll);
+  onScroll();
+  if(toTop) toTop.addEventListener('click',()=>window.scrollTo({top:0,behavior:'smooth'}));
+
+  const copyBtn=document.getElementById('copyLink');
+  if(copyBtn){
+    copyBtn.addEventListener('click',()=>{
+      navigator.clipboard.writeText(copyBtn.dataset.url).then(()=>{
+        const txt=copyBtn.textContent;
+        copyBtn.textContent='Copied!';
+        setTimeout(()=>{copyBtn.textContent=txt;},1500);
+      });
+    });
+  }
+});

--- a/front-page.php
+++ b/front-page.php
@@ -1,215 +1,49 @@
-<?php /* Template Name: Android Development Studio Landing */ ?>
-<!DOCTYPE html>
-<html <?php language_attributes(); ?>>
-<head>
-  <meta charset="<?php bloginfo('charset'); ?>" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title><?php bloginfo('name'); ?></title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>
-    body { font-family: 'Inter', sans-serif; }
-    .hero-gradient { background: linear-gradient(135deg, #f0f9ff 0%, #e6f7ff 100%); }
-  </style>
-  <?php wp_head(); ?>
-</head>
-<body>
-  <!-- Header -->
-  <header class="bg-white shadow-sm py-4">
-    <div class="container mx-auto px-6 flex justify-between items-center">
-      <div class="flex items-center">
-        <div class="w-10 h-10 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold text-xl">A</div>
-        <span class="ml-3 text-xl font-bold">Android Dev Studio</span>
-      </div>
-      <nav class="hidden md:flex space-x-8">
-        <a href="#" class="text-gray-600 hover:text-blue-600">Android AI</a>
-        <a href="#" class="text-gray-600 hover:text-blue-600">Phones</a>
-        <a href="#" class="text-gray-600 hover:text-blue-600">iOS Updates</a>
-        <a href="#" class="text-gray-600 hover:text-blue-600">How To & SEO</a>
-        <a href="#" class="text-gray-600 hover:text-blue-600">Privacy & VPN</a>
-        <a href="#" class="text-gray-600 hover:text-blue-600">Social Marketing</a>
-      </nav>
-      <div class="flex items-center space-x-4">
-        <button class="text-gray-600 font-medium">Sign In</button>
-        <button class="bg-blue-600 text-white px-5 py-2 rounded-lg font-medium hover:bg-blue-700 transition">Get Started</button>
-      </div>
-    </div>
-  </header>
-
-  <!-- Hero Section -->
-  <section class="hero-gradient py-20">
-    <div class="container mx-auto px-6 flex flex-col md:flex-row items-center">
-      <div class="md:w-1/2 mb-12 md:mb-0">
-        <h1 class="text-4xl md:text-5xl font-bold leading-tight text-gray-900 mb-6">
-          Android insights.<br/>Stay ahead of the curve.
-        </h1>
-        <p class="text-xl text-gray-600 mb-8">
-          Tutorials, tools and news for developers and mobile enthusiasts.
-        </p>
-        <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4">
-          <button class="bg-blue-600 text-white px-8 py-4 rounded-lg font-medium text-lg hover:bg-blue-700 transition">
-            Explore Guides
-          </button>
-          <button class="border-2 border-gray-300 text-gray-700 px-8 py-4 rounded-lg font-medium text-lg hover:bg-gray-50 transition">
-            Latest News
-          </button>
-        </div>
-      </div>
-      <div class="md:w-1/2 flex justify-center">
-        <div class="relative">
-          <div class="bg-gray-200 border-2 border-dashed rounded-xl w-full h-96 flex items-center justify-center text-gray-500">
-            Device Dashboard Preview
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Category Grid -->
-  <section class="py-20 bg-white">
-    <div class="container mx-auto px-6">
-      <h2 class="text-3xl font-bold text-center mb-16">Browse key categories</h2>
-
-      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-8">
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">AI Tools</span>
-        </div>
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">Android Apps</span>
-        </div>
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">iOS Tips</span>
-        </div>
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">SEO Tools</span>
-        </div>
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">Best VPNs</span>
-        </div>
-        <div class="flex flex-col items-center p-4 hover:bg-gray-50 rounded-lg transition">
-          <div class="bg-gray-200 rounded-xl w-16 h-16 mb-3"></div>
-          <span class="font-medium text-center">Marketing Trends</span>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- How It Works -->
-  <section class="py-20 bg-gray-50">
-    <div class="container mx-auto px-6">
-      <h2 class="text-3xl font-bold text-center mb-4">Get started in 3 steps</h2>
-      <p class="text-gray-600 text-center max-w-2xl mx-auto mb-16">Learn, build and launch with our community resources.</p>
-
-      <div class="grid md:grid-cols-3 gap-8">
-        <div class="bg-white p-8 rounded-xl shadow-sm">
-          <div class="text-blue-600 font-bold text-2xl mb-4">1</div>
-          <h3 class="font-bold text-xl mb-3">Choose a topic</h3>
-          <p class="text-gray-600">Select from Android, iOS, SEO and more.</p>
-        </div>
-
-        <div class="bg-white p-8 rounded-xl shadow-sm">
-          <div class="text-blue-600 font-bold text-2xl mb-4">2</div>
-          <h3 class="font-bold text-xl mb-3">Follow the guide</h3>
-          <p class="text-gray-600">Step-by-step tutorials and tips.</p>
-        </div>
-
-        <div class="bg-white p-8 rounded-xl shadow-sm">
-          <div class="text-blue-600 font-bold text-2xl mb-4">3</div>
-          <h3 class="font-bold text-xl mb-3">Build & share</h3>
-          <p class="text-gray-600">Apply what you learn and share with the community.</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Testimonials -->
-  <section class="py-20 bg-white">
-    <div class="container mx-auto px-6">
-      <h2 class="text-3xl font-bold text-center mb-16">Loved by developers</h2>
-
-      <div class="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
-        <div class="border border-gray-200 rounded-xl p-6">
-          <p class="text-gray-600 mb-6">"This site keeps me up to date with Android news and tools."</p>
-          <div class="flex items-center">
-            <img src="/assets/user1.jpg" alt="User" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
-            <div class="ml-4">
-              <h4 class="font-bold">Sarah K.</h4>
-              <p class="text-gray-600">App Developer</p>
-            </div>
-          </div>
-        </div>
-        <div class="border border-gray-200 rounded-xl p-6">
-          <p class="text-gray-600 mb-6">"The SEO guides helped my blog traffic skyrocket."</p>
-          <div class="flex items-center">
-            <img src="/assets/user2.jpg" alt="User" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
-            <div class="ml-4">
-              <h4 class="font-bold">James L.</h4>
-              <p class="text-gray-600">Blogger</p>
-            </div>
-          </div>
-        </div>
-        <div class="border border-gray-200 rounded-xl p-6">
-          <p class="text-gray-600 mb-6">"Great resource for choosing the right VPN."</p>
-          <div class="flex items-center">
-            <img src="/assets/user3.jpg" alt="User" class="w-12 h-12 rounded-full object-cover" loading="lazy" />
-            <div class="ml-4">
-              <h4 class="font-bold">Priya S.</h4>
-              <p class="text-gray-600">Security Analyst</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Footer -->
-  <footer class="bg-gray-900 text-white py-16">
-    <div class="container mx-auto px-6">
-      <div class="grid md:grid-cols-5 gap-8">
-        <div class="md:col-span-2">
-          <div class="flex items-center mb-6">
-            <div class="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-white font-bold">A</div>
-            <span class="ml-2 text-xl font-bold">Android Dev Studio</span>
-          </div>
-          <p class="text-gray-400 max-w-xs">Resources and insights for mobile development and marketing pros.</p>
-        </div>
-
-        <div>
-          <h4 class="font-bold mb-4">Product</h4>
-          <ul class="space-y-2 text-gray-400">
-            <li><a href="#" class="hover:text-white">Features</a></li>
-            <li><a href="#" class="hover:text-white">Pricing</a></li>
-            <li><a href="#" class="hover:text-white">FAQ</a></li>
-          </ul>
-        </div>
-
-        <div>
-          <h4 class="font-bold mb-4">Resources</h4>
-          <ul class="space-y-2 text-gray-400">
-            <li><a href="#" class="hover:text-white">Blog</a></li>
-            <li><a href="#" class="hover:text-white">Guides</a></li>
-          </ul>
-        </div>
-
-        <div>
-          <h4 class="font-bold mb-4">Community</h4>
-          <ul class="space-y-2 text-gray-400">
-            <li><a href="#" class="hover:text-white">Forum</a></li>
-            <li><a href="#" class="hover:text-white">Contact</a></li>
-          </ul>
-        </div>
-      </div>
-      <div class="border-t border-gray-800 mt-12 pt-8 text-gray-400 text-sm">
-        © <?php echo date('Y'); ?> Android Dev Studio. All rights reserved.
-      </div>
-    </div>
-  </footer>
-
-  <?php wp_footer(); ?>
-</body>
-</html>
+<?php
+/* Front Page */
+get_header();
+?>
+<section class="home-hero">
+<?php
+$hero_q = new WP_Query(['posts_per_page'=>1]);
+if($hero_q->have_posts()):
+  while($hero_q->have_posts()): $hero_q->the_post(); ?>
+    <h1 class="hero-title"><?php the_title(); ?></h1>
+    <?php if(has_post_thumbnail()): ?><div class="thumb-wrap hero-thumb"><?php the_post_thumbnail('featured-16x9',['loading'=>'lazy','decoding'=>'async']); ?></div><?php endif; ?>
+    <p class="meta"><?php echo esc_html( mgstyle_trim_excerpt() ); ?></p>
+    <a class="btn btn-cta" href="<?php the_permalink(); ?>"><?php _e('Read latest','minimal-gstyle'); ?></a>
+<?php
+  endwhile;
+  wp_reset_postdata();
+endif; ?>
+</section>
+<section class="list">
+<?php
+$posts_q = new WP_Query(['posts_per_page'=>6, 'offset'=>1]);
+if($posts_q->have_posts()):
+  while($posts_q->have_posts()): $posts_q->the_post(); ?>
+    <article id="post-<?php the_ID(); ?>" <?php post_class('card'); ?>>
+      <?php if(has_post_thumbnail()): ?><div class="thumb-wrap"><?php the_post_thumbnail('card-thumb',['loading'=>'lazy','decoding'=>'async','sizes'=>'(max-width:600px) 100vw, 50vw']); ?></div><?php endif; ?>
+      <h2><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+      <div class="meta"><?php echo get_the_date('M j, Y'); ?><?php $cats=get_the_category(); if($cats){ echo ' • <span class="badge">'.esc_html($cats[0]->name).'</span>'; } ?></div>
+      <p><?php echo esc_html( mgstyle_trim_excerpt() ); ?></p>
+      <a class="btn btn-cta" href="<?php the_permalink(); ?>"><?php _e('Read','minimal-gstyle'); ?></a>
+    </article>
+<?php
+  endwhile;
+  wp_reset_postdata();
+else: ?>
+  <p class="meta"><?php _e('No posts yet','minimal-gstyle'); ?></p>
+<?php endif; ?>
+</section>
+<section class="category-grid">
+  <h2><?php _e('Browse Categories','minimal-gstyle'); ?></h2>
+  <div class="chips">
+  <?php
+    $cats=get_categories(['number'=>6]);
+    foreach($cats as $cat){
+      echo '<a class="chip" href="'.esc_url(get_category_link($cat->term_id)).'">'.esc_html($cat->name).'</a> ';
+    }
+  ?>
+  </div>
+</section>
+<?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -68,3 +68,8 @@ filter:blur(44px)}
 @media (max-width:899px){.bottom-nav{display:block}main.container{padding-bottom:76px}}
 [data-theme="dark"]{--bg:#0a0e13;--surface:rgba(15,19,24,.68);--text:#e9eef5;--muted:#9ba9bb;--border:rgba(255,255,255,.08);
 --shadow1:0 8px 20px rgba(0,0,0,.35);--shadow2:0 24px 60px rgba(0,0,0,.5);color-scheme:dark}
+.home-hero{padding:60px 0;text-align:center;display:flex;flex-direction:column;align-items:center;gap:18px}
+.home-hero .hero-title{font-size:clamp(32px,6vw,56px);letter-spacing:-.02em}
+.home-hero .hero-thumb{max-width:800px;width:100%}
+.category-grid{text-align:center;padding:40px 0}
+.category-grid .chips{display:flex;flex-wrap:wrap;justify-content:center;gap:10px;margin-top:16px}


### PR DESCRIPTION
## Summary
- Replace static Tailwind-based front page with theme-driven template highlighting latest post, recent articles, and category chips
- Add vanilla JS for mobile navigation, search suggestions, table of contents, scroll progress and copy-link
- Document theme features and customization options in README

## Testing
- `php -l front-page.php`
- `node --check assets/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68976e97ebb883338f8d673c254cf2e1