### PR TITLE
Add wp_body_open hook to header template

### DIFF
--- a/header.php
+++ b/header.php
@@ -6,6 +6,7 @@
   <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
 <div class="progress" id="progress"></div>
 <header class="site-header" role="banner">
   <div class="container header-inner">


### PR DESCRIPTION
## Summary
- Add `wp_body_open()` call immediately after `<body>` in `header.php` to fire the `wp_body_open` action for plugins and accessibility hooks.

## Testing
- `php -l header.php`

------
https://chatgpt.com/codex/tasks/task_e_68977844005083339ad7bb480cdbe179