### PR TITLE
Ensure wp_body_open runs and improve mobile viewport

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,11 @@
 <?php
+
+if ( ! function_exists( 'wp_body_open' ) ) {
+  function wp_body_open() {
+    do_action( 'wp_body_open' );
+  }
+}
+
 function mgstyle_setup() {
   add_theme_support('title-tag');
   add_theme_support('post-thumbnails');

--- a/header.php
+++ b/header.php
@@ -2,7 +2,7 @@
 <html <?php language_attributes(); ?>>
 <head>
   <meta charset="<?php echo esc_html( get_bloginfo( 'charset' ) ); ?>" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>


### PR DESCRIPTION
## Summary
- add `wp_body_open` fallback for better plugin compatibility
- refine viewport meta tag for safer mobile rendering

## Testing
- `php -l header.php functions.php`


------
https://chatgpt.com/codex/tasks/task_e_6897863ab7308333b286a3dbdebcc42a